### PR TITLE
Fix placeholder for postgres.

### DIFF
--- a/postgresql/postgresql.ml
+++ b/postgresql/postgresql.ml
@@ -3,7 +3,7 @@
 open Printf
 open Sequoia.Common
 
-module D = struct let placeholder _ = "?" end
+module D = struct let placeholder n = Printf.sprintf "$%d" n end
 module M = Sequoia.Make (D)
 
 include (M : module type of M


### PR DESCRIPTION
Hi there! I've tried to use sequoia-postgresql with pgocaml and found that placeholder seems to be wrong. I'm not fluent with sql, but I see that postgres prepare statements do not accept params as ?:
```
sudo -u postgres psql
[sudo] password for username: 
psql (10.6 (Ubuntu 10.6-0ubuntu0.18.04.1))
Type "help" for help.

postgres=# CREATE TEMPORARY TABLE users (id serial PRIMARY KEY, name VARCHAR(255) NOT NULL);
CREATE TABLE
postgres=# PREPARE my AS SELECT users.id, users.name FROM users WHERE ((users.id) = (?));
ERROR:  syntax error at or near ")"
LINE 1: ...CT users.id, users.name FROM users WHERE ((users.id) = (?));
                                                                    ^
postgres=# PREPARE my AS SELECT users.id, users.name FROM users WHERE ((users.id) = ($1));
PREPARE
postgres=#
```